### PR TITLE
Fix build for OSX 10.7+

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -16,6 +16,21 @@
         'dependencies': [
             "<!(node -p \"require('node-addon-api').gyp\")"
         ],
-        'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS' ]
+        'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS' ],
+        'conditions': [
+        [
+          'OS=="mac"', {
+            'xcode_settings': {
+              'OTHER_CFLAGS': [
+                '-mmacosx-version-min=10.7',
+                '-std=c++11',
+                '-stdlib=libc++'
+              ],
+              'GCC_ENABLE_CPP_RTTI': 'YES',
+              'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
+            }
+          }
+        ]
+      ]
     }]
 }


### PR DESCRIPTION
When building RocketRML on OSX, this dependency fails:
```
  CXX(target) Release/obj.target/xpathWrapper/cppsrc/xpath/xpathParser.o
../cppsrc/xpath/xpathParser.cpp:35:7: error: cannot use 'try' with exceptions disabled
      try {
      ^
../cppsrc/xpath/xpathParser.cpp:19:5: error: cannot use 'try' with exceptions disabled
    try {
    ^
../cppsrc/xpath/xpathParser.cpp:16:3: error: cannot use 'try' with exceptions disabled
  try {
  ^

```
Fixed using 
https://github.com/nodejs/node-gyp/issues/1215